### PR TITLE
Mark thermostat unavailable if not recently seen

### DIFF
--- a/custom_components/e_thermostaat/climate.py
+++ b/custom_components/e_thermostaat/climate.py
@@ -170,7 +170,7 @@ class EThermostaat(ClimateEntity):
         return self._target_temperature
     
     @property
-    def available() -> bool:
+    def available(self) -> bool:
         return self._last_seen and datetime.datetime.now() - self._last_seen < datetime.timedelta(seconds=600)
 
     @property

--- a/custom_components/e_thermostaat/climate.py
+++ b/custom_components/e_thermostaat/climate.py
@@ -171,6 +171,7 @@ class EThermostaat(ClimateEntity):
     
     @property
     def available(self) -> bool:
+        """Return True if entity is available."""
         return self._last_seen and datetime.datetime.now() - self._last_seen < datetime.timedelta(seconds=600)
 
     @property

--- a/custom_components/e_thermostaat/climate.py
+++ b/custom_components/e_thermostaat/climate.py
@@ -4,6 +4,8 @@ Adds support for the Essent Icy E-Thermostaat units.
 For more details about this platform, please refer to the documentation at
 https://github.com/custom-components/climate.e_thermostaat
 """
+import datetime
+
 import logging
 
 import requests
@@ -118,6 +120,7 @@ class EThermostaat(ClimateEntity):
 
         self._current_temperature = None
         self._target_temperature = None
+        self._last_seen = None
         self._old_conf = None
         self._current_operation_mode = None
 
@@ -165,6 +168,10 @@ class EThermostaat(ClimateEntity):
     def target_temperature(self):
         """Return the temperature we try to reach."""
         return self._target_temperature
+    
+    @property
+    def available() -> bool:
+        return self._last_seen and datetime.datetime.now() - self._last_seen < datetime.timedelta(seconds=600)
 
     @property
     def hvac_mode(self):
@@ -303,6 +310,8 @@ class EThermostaat(ClimateEntity):
 
             self._target_temperature = data["temperature1"]
             self._current_temperature = data["temperature2"]
+            
+            self._last_seen = datetime.datetime.strptime(data["last-seen"], '%Y-%m-%d %H:%M:%S')
 
             self._old_conf = data["configuration"]
             self._current_operation_mode = self.map_int_to_operation_mode(


### PR DESCRIPTION
This resolves #14.

The last_seen reported by ICY is reported without timezone information, I assume Europe/Amsterdam. This change doesn't take timezones into account and thus requires HASS to be run in the same timezone. 

HASS UI:

<img width="377" alt="image" src="https://user-images.githubusercontent.com/235882/129860189-321c73e0-2c1d-4870-81eb-e3cc95a2fb54.png">

macOS Home app:

<img width="114" alt="image" src="https://user-images.githubusercontent.com/235882/129860322-779f4637-1389-43a3-8b80-f46463e8e201.png">
